### PR TITLE
Implement active WPM tracking

### DIFF
--- a/doc
+++ b/doc
@@ -30,7 +30,7 @@ Scripting
     -oneshot            Automatically exit after a single run.
     -noreport           Don't show a report at the end of a test.
     -csv                Print the test results to stdout in the form:
-                        [wpm],[cpm],[accuracy],[timestamp].
+                        [wpm],[activewpm],[cpm],[accuracy],[timestamp].
     -raw                Don't reflow STDIN text or show one paragraph at a time. 
                         Note that line breaks are determined exclusively by the 
                         input.

--- a/man.md
+++ b/man.md
@@ -115,7 +115,7 @@ usage: tt \[OPTION\]... \[FILE\]
 	Tests have the form:
 
 	```
-	test,[wpm],[cpm],[accuracy],[timestamp].
+        test,[wpm],[activewpm],[cpm],[accuracy],[timestamp].
 	```
 
 	Mistakes have the form:

--- a/src/tt.go
+++ b/src/tt.go
@@ -22,6 +22,7 @@ var jsonMode bool
 
 type result struct {
 	Wpm       int       `json:"wpm"`
+	ActiveWpm int       `json:"activewpm"`
 	Cpm       int       `json:"cpm"`
 	Accuracy  float64   `json:"accuracy"`
 	Timestamp int64     `json:"timestamp"`
@@ -76,7 +77,7 @@ func exit(rc int) {
 
 	if csvMode {
 		for _, r := range results {
-			fmt.Printf("test,%d,%d,%.2f,%d\n", r.Wpm, r.Cpm, r.Accuracy, r.Timestamp)
+			fmt.Printf("test,%d,%d,%d,%.2f,%d\n", r.Wpm, r.ActiveWpm, r.Cpm, r.Accuracy, r.Timestamp)
 			for _, m := range r.Mistakes {
 				fmt.Printf("mistake,%s,%s\n", m.Word, m.Typed)
 			}
@@ -86,7 +87,7 @@ func exit(rc int) {
 	os.Exit(rc)
 }
 
-func showReport(scr tcell.Screen, cpm, wpm int, accuracy float64, attribution string, mistakes []mistake) {
+func showReport(scr tcell.Screen, cpm, wpm, activeWpm int, accuracy float64, attribution string, mistakes []mistake) {
 	mistakeStr := ""
 	if attribution != "" {
 		attribution = "\n\nAttribution: " + attribution
@@ -102,7 +103,7 @@ func showReport(scr tcell.Screen, cpm, wpm int, accuracy float64, attribution st
 		}
 	}
 
-	report := fmt.Sprintf("WPM:         %d\nCPM:         %d\nAccuracy:    %.2f%%%s%s", wpm, cpm, accuracy, mistakeStr, attribution)
+	report := fmt.Sprintf("WPM:         %d\nActive WPM:  %d\nCPM:         %d\nAccuracy:    %.2f%%%s%s", wpm, activeWpm, cpm, accuracy, mistakeStr, attribution)
 
 	scr.Clear()
 	drawStringAtCenter(scr, report, tcell.StyleDefault)
@@ -383,7 +384,7 @@ func main() {
 	typer.ShowWpm = showWpm
 
 	if timeout != -1 {
-		timeout *= 1E9
+		timeout *= 1e9
 	}
 
 	var tests [][]segment
@@ -415,17 +416,23 @@ func main() {
 				idx--
 			}
 		case TyperComplete:
-			cpm := int(float64(ncorrect) / (float64(t) / 60E9))
+			cpm := int(float64(ncorrect) / (float64(t) / 60e9))
 			wpm := cpm / 5
+			activeCpm := 0
+			activeWpm := 0
+			if typer.ActiveDuration > 0 {
+				activeCpm = int(float64(ncorrect) / (float64(typer.ActiveDuration) / 60e9))
+				activeWpm = activeCpm / 5
+			}
 			accuracy := float64(ncorrect) / float64(nerrs+ncorrect) * 100
 
-			results = append(results, result{wpm, cpm, accuracy, time.Now().Unix(), mistakes})
+			results = append(results, result{wpm, activeWpm, cpm, accuracy, time.Now().Unix(), mistakes})
 			if !noReport {
 				attribution := ""
 				if len(tests[idx]) == 1 {
 					attribution = tests[idx][0].Attribution
 				}
-				showReport(scr, cpm, wpm, accuracy, attribution, mistakes)
+				showReport(scr, cpm, wpm, activeWpm, accuracy, attribution, mistakes)
 			}
 			if oneShotMode {
 				exit(0)


### PR DESCRIPTION
## Summary
- record active typing time and compute active WPM
- output active WPM in CSV results and final report
- document the new CSV column in `doc` and `man.md`

## Testing
- `go vet ./...` *(fails: unable to download dependencies)*
- `go build ./...` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684736b818b4832b9c7dce2048b5fb4b