### PR TITLE
Implement dynamic WPM graph feature

### DIFF
--- a/doc
+++ b/doc
@@ -29,6 +29,7 @@ Test Parameters
 Scripting
     -oneshot            Automatically exit after a single run.
     -noreport           Don't show a report at the end of a test.
+    -nograph            Disable the WPM graph in the report.
     -csv                Print the test results to stdout in the form:
                         [wpm],[activewpm],[cpm],[accuracy],[timestamp].
     -raw                Don't reflow STDIN text or show one paragraph at a time. 

--- a/man.md
+++ b/man.md
@@ -108,6 +108,10 @@ usage: tt \[OPTION\]... \[FILE\]
 
 : Don't show a report at the end of a test.
 
+-nograph
+
+: Disable the WPM graph in the report.
+
 -csv
 
 : Print CSV formatted results.


### PR DESCRIPTION
## Summary
- show dynamic WPM graph when test ends
- add `-nograph` flag to disable the graph
- record WPM history during typing
- document the new option

## Testing
- `gofmt -w src/tt.go src/typer.go`
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68473cf4cea0832ba6beeb6c1a6d1d65