### PR TITLE
Simplify WPM features

### DIFF
--- a/doc
+++ b/doc
@@ -29,8 +29,9 @@ Test Parameters
 Scripting
     -oneshot            Automatically exit after a single run.
     -noreport           Don't show a report at the end of a test.
+    -nograph            Disable the WPM graph in the report.
     -csv                Print the test results to stdout in the form:
-                        [wpm],[activewpm],[cpm],[accuracy],[timestamp].
+                        [wpm],[cpm],[accuracy],[timestamp].
     -raw                Don't reflow STDIN text or show one paragraph at a time. 
                         Note that line breaks are determined exclusively by the 
                         input.

--- a/man.md
+++ b/man.md
@@ -108,6 +108,10 @@ usage: tt \[OPTION\]... \[FILE\]
 
 : Don't show a report at the end of a test.
 
+-nograph
+
+: Disable the WPM graph in the report.
+
 -csv
 
 : Print CSV formatted results.
@@ -115,7 +119,7 @@ usage: tt \[OPTION\]... \[FILE\]
 	Tests have the form:
 
 	```
-        test,[wpm],[activewpm],[cpm],[accuracy],[timestamp].
+       test,[wpm],[cpm],[accuracy],[timestamp].
 	```
 
 	Mistakes have the form:


### PR DESCRIPTION
## Summary
- prune ActiveWPM tracking
- add labels to WPM graph
- compute live WPM directly

## Testing
- `gofmt -w src/tt.go src/typer.go`
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68473cf4cea0832ba6beeb6c1a6d1d65